### PR TITLE
Structure Query

### DIFF
--- a/queries/structure.scm
+++ b/queries/structure.scm
@@ -1,0 +1,29 @@
+(require_directive
+  "require" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)
+
+(exclude_directive
+  "exclude" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)
+
+(module_directive
+  "module" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)
+
+(replace_directive
+  "replace" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)
+
+(retract_directive
+  "retract" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)


### PR DESCRIPTION
This adds a "structure.scm" query definition file. This can be used to find related syntactic elements and to drive a parse-tree-based indentation system.

gomod's grammar is pretty simple, so this one isn't to tricky. But, if you're interested in seeing something more complex, the version for Go was just [merged](https://github.com/tree-sitter/tree-sitter-go/pull/70).