### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target
 *.o
 bindings/c/*.h
 bindings/c/tree-sitter-*.pc
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterGoMod",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterGoMod", targets: ["TreeSitterGoMod"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterGoMod",
+                path: ".",
+                exclude: [
+                    "binding.gyp",
+                    "bindings",
+                    "Cargo.toml",
+                    "corpus",
+                    "grammar.js",
+                    "LICENSE",
+                    "Makefile",
+                    "package.json",
+                    "README.md",
+                    "src/node-types.json",
+                    "src/grammar.json",
+                ],
+                sources: [
+                    "src/parser.c",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/TreeSitterGoMod/gomod.h
+++ b/bindings/swift/TreeSitterGoMod/gomod.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_GO_MOD_H_
+#define TREE_SITTER_GO_MOD_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_gomod();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_GOMOD_H_


### PR DESCRIPTION
Swift's package manager can build C/C++ sources and use headers to expose functions to Swift. The standard tree-sitter parser project layout just requires a little extra configuration to make it happy.