### PR TITLE
fix(rust-binding): bump tree-sitter 0.17 to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,13 @@ edition = "2018"
 license = "MIT"
 
 build = "bindings/rust/build.rs"
-include = [
-  "bindings/rust/*",
-  "grammar.js",
-  "queries/*",
-  "src/*",
-]
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 
 [lib]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.17"
+tree-sitter = "0.20"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -2,7 +2,7 @@ fn main() {
     let src_dir = std::path::Path::new("src");
 
     let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
+    c_config.include(src_dir);
     c_config
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -31,7 +31,7 @@ pub fn language() -> Language {
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 


### PR DESCRIPTION
An error occurred while setting `tree-sitter-gomod` as language in rust.

Currently, this test fails with a `tree-sitter` version of 0.17.
https://github.com/camdencheek/tree-sitter-go-mod/blob/af4270aed18500af1d24e6de5f6e7d243e2c8b05/bindings/rust/lib.rs#L43-L52

error log: 
```sh
thread 'tests::test_can_load_grammar' panicked at bindings/rust/lib.rs:50:14:
Error loading gomod language: LanguageError { version: 14 }
...
```

In `parser.c`, `LANGUAGE_VERSION` is specified as 14, 
https://github.com/camdencheek/tree-sitter-go-mod/blob/af4270aed18500af1d24e6de5f6e7d243e2c8b05/src/parser.c#L8
rust `tree-sitter-0.17.1` only allows versions from 9..=12.

Since `tree-sitter-0.20.10` allows 13..=14, I think we should bump the version.