### PR TITLE
chore(rust): bump `tree-sitter` version to `v0.22`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.20"
+tree-sitter = "0.22"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -46,7 +46,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
+            .set_language(&super::language())
             .expect("Error loading gomod language");
     }
 }


### PR DESCRIPTION
rust dependencies `tree-sitter` v0.21 and v0.20 are incompatible, so this is a PR to update to the v0.22.

The difference from the previous version is that the input of `tree_sitter::Query::new` has been changed to borrow `Language`.

> `Copy` trait derive has disappeared, and `LanguageRef` has been added.

Please refer to PR [#2840](https://github.com/tree-sitter/tree-sitter/pull/2840/files).
